### PR TITLE
Handle self-paced courses by not saving due dates in the database.

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -18,7 +18,7 @@ from edx_when import models
 
 log = logging.getLogger('edx-when')
 
-FIELDS_TO_EXTRACT = ('due', 'start')
+FIELDS_TO_EXTRACT = ('due', 'start', 'end')
 
 
 def _ensure_key(key_class, key_obj):
@@ -60,6 +60,14 @@ def set_dates_for_course(course_key, items):
                 if val:
                     log.info('Setting date for %r, %s, %r', location, field, val)
                     set_date_for_block(course_key, location, field, val)
+
+
+def clear_dates_for_course(course_key):
+    """
+    Set all dates to inactive.
+    """
+    course_key = _ensure_key(CourseKey, course_key)
+    models.ContentDate.objects.filter(course_id=course_key, active=True).update(active=False)
 
 
 def get_dates_for_course(course_id, user=None, use_cached=True):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,13 @@ class ApiTests(TestCase):
         # second time is cached
         retrieved = api.get_dates_for_course(items[0][0].course_key)
         assert len(retrieved) == 3
+        return items
+
+    def test_clear_dates_for_course(self):
+        items = self.test_get_dates_for_course()
+        api.clear_dates_for_course(items[0][0].course_key)
+        retrieved = api.get_dates_for_course(items[0][0].course_key, use_cached=False)
+        assert not retrieved
 
     def test_set_user_override(self):
         items = make_items()


### PR DESCRIPTION
For [PROD-291](https://openedx.atlassian.net/browse/PROD-291).

Self-paced courses will not store due dates in edx-when. Only the course start and end dates will be in the database.
