### PR TITLE
Changed course enablement check to look at the database rather than a waffle flag

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -5,9 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-import crum
 import six
-import waffle
 from django.core.exceptions import ValidationError
 from django.utils.dateparse import parse_datetime
 from edx_django_utils.cache.utils import DEFAULT_REQUEST_CACHE
@@ -27,14 +25,11 @@ def _ensure_key(key_class, key_obj):
     return key_obj
 
 
-def is_enabled_for_course(course_key, request=None):
+def is_enabled_for_course(course_key):
     """
     Return whether edx-when is enabled for this course.
     """
-    request = request or crum.get_current_request()
-    if not waffle.flag_is_active(request, 'edx-when-enabled'):
-        return waffle.flag_is_active(request, 'edx-when:{}'.format(course_key))
-    return True
+    return models.ContentDate.objects.filter(course_id=course_key, active=True).exists()
 
 
 def override_enabled():

--- a/edx_when/field_data.py
+++ b/edx_when/field_data.py
@@ -39,9 +39,8 @@ class DateLookupFieldData(FieldData):
         Load the dates from the database.
         """
         dates = {}
-        if api.is_enabled_for_course(course_id):
-            for (location, field), date in api.get_dates_for_course(course_id, user, use_cached=use_cached).items():
-                dates[text_type(location), field] = date
+        for (location, field), date in api.get_dates_for_course(course_id, user, use_cached=use_cached).items():
+            dates[text_type(location), field] = date
         self._course_dates = dates
 
     def has(self, block, name):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,5 +5,3 @@ django-model-utils        # Provides TimeStampedModel abstract base class
 edx-opaque-keys
 edx-drf-extensions
 xblock
-django-waffle
-django-crum

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,25 +6,21 @@
 #
 appdirs==1.4.3            # via fs
 backports.os==0.1.1       # via fs
-certifi==2019.3.9         # via requests
-chardet==3.0.4            # via requests
-django-crum==0.7.3
 django-model-utils==3.1.2
-django-waffle==0.16.0
+django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2  # via edx-drf-extensions, rest-condition
+djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.0
-edx-opaque-keys==0.4.4
+edx-drf-extensions==2.3.0
+edx-opaque-keys==1.0.0
 enum34==1.1.6             # via fs
-fs==2.4.4                 # via xblock
+fs==2.4.5                 # via xblock
 future==0.17.1            # via backports.os, pyjwkest
-idna==2.8                 # via requests
 lxml==4.3.3               # via xblock
 markupsafe==1.1.1         # via xblock
-newrelic==4.18.0.118      # via edx-django-utils
-pbr==5.1.3                # via stevedore
+newrelic==4.20.0.120      # via edx-django-utils
+pbr==5.2.0                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.8.1      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -33,13 +29,12 @@ pymongo==3.8.0            # via edx-opaque-keys
 python-dateutil==2.8.0    # via edx-drf-extensions, xblock
 pytz==2019.1              # via django, fs, xblock
 pyyaml==5.1               # via xblock
-requests==2.21.0          # via edx-drf-extensions, pyjwkest
+requests==2.22.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.12.0               # via edx-drf-extensions, edx-opaque-keys, fs, pyjwkest, python-dateutil, stevedore, xblock
 stevedore==1.30.1         # via edx-opaque-keys
 typing==3.6.6             # via fs
-urllib3==1.24.2           # via requests
 web-fragments==0.3.0      # via xblock
 webob==1.8.5              # via xblock
 xblock==1.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,61 +11,56 @@ atomicwrites==1.3.0
 attrs==19.1.0
 backports.functools-lru-cache==1.5
 backports.os==0.1.1
-caniusepython3==7.0.0
-certifi==2019.3.9
-chardet==3.0.4
+caniusepython3==7.1.0
 click-log==0.3.2
 click==7.0
 code-annotations==0.3.1
 codecov==2.0.15
 configparser==3.7.4
-contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3
-diff-cover==2.0.0
-distlib==0.2.8
-django-crum==0.7.3
+diff-cover==2.0.1
+distlib==0.2.9.post0
 django-model-utils==3.1.2
 django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.2
+djangorestframework==3.9.4
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
+edx-drf-extensions==2.3.0
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
-edx-opaque-keys==0.4.4
+edx-lint==1.2.1
+edx-opaque-keys==1.0.0
 enum34==1.1.6
-filelock==3.0.10
-fs==2.4.4
+filelock==3.0.12
+fs==2.4.5
 funcsigs==1.0.2
 future==0.17.1
 futures==3.2.0 ; python_version <= "3"
-idna==2.8
-importlib-metadata==0.9   # via path.py
+importlib-metadata==0.15
 inflect==2.1.0            # via jinja2-pluralize
-isort==4.3.17
+isort==4.3.20
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1
-lazy-object-proxy==1.3.1
+lazy-object-proxy==1.4.1
 lxml==4.3.3
 markupsafe==1.1.1
 mccabe==0.6.1
-mock==2.0.0
+mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 packaging==19.0
 path.py==11.5.0
 pathlib2==2.3.3
-pbr==5.1.3
-pip-tools==3.6.1
-pluggy==0.9.0
+pbr==5.2.0
+pip-tools==3.7.0
+pluggy==0.12.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py==1.8.0
 pycodestyle==2.5.0
 pycryptodomex==3.8.1
 pydocstyle==3.0.0
-pygments==2.3.1           # via diff-cover
+pygments==2.4.2           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pylint-celery==0.3
@@ -74,14 +69,14 @@ pylint-plugin-utils==0.5
 pylint==1.7.6
 pymongo==3.8.0
 pyparsing==2.4.0
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.5.0
 python-dateutil==2.8.0
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 scandir==1.10.0
 semantic-version==2.6.0
@@ -92,12 +87,11 @@ stevedore==1.30.1
 text-unidecode==1.2
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.9.0
+tox==3.12.1
 typing==3.6.6
-urllib3==1.24.2
-virtualenv==16.5.0
+virtualenv==16.6.0
+wcwidth==0.1.7
 web-fragments==0.3.0
 webob==1.8.5
 wrapt==1.11.1
 xblock==1.2.2
-zipp==0.3.3               # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,59 +8,57 @@ alabaster==0.7.12         # via sphinx
 appdirs==1.4.3
 atomicwrites==1.3.0
 attrs==19.1.0
-babel==2.6.0              # via sphinx
+babel==2.7.0              # via sphinx
 backports.os==0.1.1
 bleach==3.1.0             # via readme-renderer
-certifi==2019.3.9
-chardet==3.0.4
+chardet==3.0.4            # via doc8
 click==7.0
 code-annotations==0.3.1
 coverage==4.5.3
-django-crum==0.7.3
 django-model-utils==3.1.2
 django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.2
+djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
-edx-opaque-keys==0.4.4
+edx-drf-extensions==2.3.0
+edx-opaque-keys==1.0.0
 edx-sphinx-theme==1.4.0
 enum34==1.1.6
-fs==2.4.4
+fs==2.4.5
 funcsigs==1.0.2
 future==0.17.1
-idna==2.8
 imagesize==1.1.0          # via sphinx
+importlib-metadata==0.15
 jinja2==2.10.1
 lxml==4.3.3
 markupsafe==1.1.1
-mock==2.0.0
+mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 packaging==19.0           # via sphinx
 pathlib2==2.3.3
-pbr==5.1.3
-pluggy==0.9.0
+pbr==5.2.0
+pluggy==0.12.0
 psutil==1.2.1
 py==1.8.0
 pycryptodomex==3.8.1
-pygments==2.3.1           # via readme-renderer, sphinx
+pygments==2.4.2           # via readme-renderer, sphinx
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pymongo==3.8.0
 pyparsing==2.4.0          # via packaging
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.5.0
 python-dateutil==2.8.0
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1
 readme-renderer==24.0
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
 scandir==1.10.0
@@ -68,11 +66,11 @@ semantic-version==2.6.0
 six==1.12.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.30.1
 text-unidecode==1.2
 typing==3.6.6
-urllib3==1.24.2
+wcwidth==0.1.7
 web-fragments==0.3.0
 webencodings==0.5.1       # via bleach
 webob==1.8.5

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.6.1
+pip-tools==3.7.0
 six==1.12.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -11,44 +11,41 @@ atomicwrites==1.3.0
 attrs==19.1.0
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 backports.os==0.1.1
-caniusepython3==7.0.0
-certifi==2019.3.9
-chardet==3.0.4
+caniusepython3==7.1.0
 click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.1
 configparser==3.7.4       # via pydocstyle, pylint
 coverage==4.5.3
-distlib==0.2.8            # via caniusepython3
-django-crum==0.7.3
+distlib==0.2.9.post0      # via caniusepython3
 django-model-utils==3.1.2
 django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.2
+djangorestframework==3.9.4
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
-edx-lint==1.1.2
-edx-opaque-keys==0.4.4
+edx-drf-extensions==2.3.0
+edx-lint==1.2.1
+edx-opaque-keys==1.0.0
 enum34==1.1.6
-fs==2.4.4
+fs==2.4.5
 funcsigs==1.0.2
 future==0.17.1
 futures==3.2.0 ; python_version <= "3"
-idna==2.8
-isort==4.3.17
+importlib-metadata==0.15
+isort==4.3.20
 jinja2==2.10.1
-lazy-object-proxy==1.3.1  # via astroid
+lazy-object-proxy==1.4.1  # via astroid
 lxml==4.3.3
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
-mock==2.0.0
+mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 packaging==19.0           # via caniusepython3
 pathlib2==2.3.3
-pbr==5.1.3
-pluggy==0.9.0
+pbr==5.2.0
+pluggy==0.12.0
 psutil==1.2.1
 py==1.8.0
 pycodestyle==2.5.0
@@ -62,14 +59,14 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0
 pyparsing==2.4.0          # via packaging
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.5.0
 python-dateutil==2.8.0
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 scandir==1.10.0
 semantic-version==2.6.0
@@ -79,7 +76,7 @@ snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1
 text-unidecode==1.2
 typing==3.6.6
-urllib3==1.24.2
+wcwidth==0.1.7
 web-fragments==0.3.0
 webob==1.8.5
 wrapt==1.11.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,47 +8,44 @@ appdirs==1.4.3
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 backports.os==0.1.1
-certifi==2019.3.9
-chardet==3.0.4
 click==7.0                # via code-annotations
 code-annotations==0.3.1
 coverage==4.5.3           # via pytest-cov
-django-crum==0.7.3
 django-model-utils==3.1.2
 django-waffle==0.16.0
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.2
+djangorestframework==3.9.4
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
-edx-opaque-keys==0.4.4
+edx-drf-extensions==2.3.0
+edx-opaque-keys==1.0.0
 enum34==1.1.6
-fs==2.4.4
+fs==2.4.5
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1
-idna==2.8
+importlib-metadata==0.15  # via pluggy
 jinja2==2.10.1            # via code-annotations
 lxml==4.3.3
 markupsafe==1.1.1
-mock==2.0.0
+mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.3
-pluggy==0.9.0             # via pytest
+pbr==5.2.0
+pluggy==0.12.0            # via pytest
 psutil==1.2.1
 py==1.8.0                 # via pytest
 pycryptodomex==3.8.1
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pymongo==3.8.0
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1             # via pytest-cov, pytest-django
+pytest==4.5.0             # via pytest-cov, pytest-django
 python-dateutil==2.8.0
 python-slugify==3.0.2     # via code-annotations
 pytz==2019.1
 pyyaml==5.1
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0
@@ -56,7 +53,7 @@ six==1.12.0
 stevedore==1.30.1
 text-unidecode==1.2       # via python-slugify
 typing==3.6.6
-urllib3==1.24.2
+wcwidth==0.1.7            # via pytest
 web-fragments==0.3.0
 webob==1.8.5
 xblock==1.2.2

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,18 +4,15 @@
 #
 #    make upgrade
 #
-certifi==2019.3.9         # via requests
-chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.3           # via codecov
-filelock==3.0.10          # via tox
-idna==2.8                 # via requests
-pluggy==0.9.0             # via tox
+filelock==3.0.12          # via tox
+importlib-metadata==0.15  # via pluggy
+pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
-requests==2.21.0          # via codecov
+requests==2.22.0          # via codecov
 six==1.12.0               # via tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.9.0
-urllib3==1.24.2           # via requests
-virtualenv==16.5.0        # via tox
+tox==3.12.1
+virtualenv==16.6.0        # via tox

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,3 +87,10 @@ class ApiTests(TestCase):
         block_id, data = items[0]
         assert api.get_date_for_block(course_id, block_id, user=self.user) == data['due']
         assert api.get_date_for_block(course_id, 'bad', user=self.user) is None
+
+    def test_is_enabled(self):
+        items = make_items()
+        course_id = items[0][0].course_key
+        assert not api.is_enabled_for_course(course_id)
+        api.set_dates_for_course(course_id, items)
+        assert api.is_enabled_for_course(course_id)


### PR DESCRIPTION
Instead of managing a bunch of waffle flags, let's just look at whether there's data in the database. If so, edx-when is enabled for that course. If not, then the course needs to be republished.
