### PR TITLE
Remove course-level due dates from self-paced courses.

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.2'
+__version__ = '0.3'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/signals.py
+++ b/edx_when/signals.py
@@ -21,7 +21,10 @@ def extract_dates(sender, course_key, **kwargs):  # pylint: disable=unused-argum
     elif course.self_paced:
         log.info('%s is self-paced. Clearing due dates', course_key)
         clear_dates_for_course(course_key)
-        date_items = [(course.location, own_metadata(course))]
+        metadata = own_metadata(course)
+        # self-paced courses may accidentally have a course due date
+        metadata.pop('due', None)
+        date_items = [(course.location, metadata)]
     else:
         log.info('Publishing course dates for %s', course_key)
         date_items = []


### PR DESCRIPTION
For [CR-1089](https://openedx.atlassian.net/browse/CR-1089):
Students can't submit problems because courses which were instructor-paced and then switched to self-paced still have active due dates in edx-when's tables.

