### PR TITLE
Correctly account for un-overriding UserDates

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.5'
+__version__ = '0.5.1'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -179,7 +179,9 @@ def set_date_for_block(course_id, block_id, field, date_or_timedelta, user=None,
     course_id = _ensure_key(CourseKey, course_id)
     block_id = _ensure_key(UsageKey, block_id)
 
-    if isinstance(date_or_timedelta, timedelta):
+    if date_or_timedelta is None:
+        date_kwargs = {'rel_date': None, 'abs_date': None}
+    elif isinstance(date_or_timedelta, timedelta):
         date_kwargs = {'rel_date': date_or_timedelta}
     else:
         date_kwargs = {'abs_date': date_or_timedelta}
@@ -194,10 +196,13 @@ def set_date_for_block(course_id, block_id, field, date_or_timedelta, user=None,
         existing_date.policy, __ = models.DatePolicy.objects.get_or_create(**date_kwargs)
 
     if user and not user.is_anonymous:
-        userd = models.UserDate(user=user, **date_kwargs)
-        userd.actor = actor
-        userd.reason = reason or ''
-        userd.content_date = existing_date
+        userd = models.UserDate(
+            user=user,
+            actor=actor,
+            reason=reason or '',
+            content_date=existing_date,
+            **date_kwargs
+        )
         try:
             userd.full_clean()
         except ValidationError:

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -98,8 +98,10 @@ class UserDate(TimeStampedModel):
         """
         if self.abs_date:
             return self.abs_date
-        else:
+        elif self.rel_date:
             return self.content_date.policy.actual_date + self.rel_date
+        else:
+            return self.content_date.policy.actual_date
 
     @property
     def location(self):


### PR DESCRIPTION
**Description:**
The existing code didn't correctly reset the returned date after an override was removed. This PR fixes that, and adds a test that verifies it.

**Reviewers:**
- [ ] @davestgermain 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)