### PR TITLE
Use the correct name for the enrollments model lookup

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 
 from django.core.exceptions import ValidationError
+from django.db.models import ObjectDoesNotExist
 from edx_django_utils.cache.utils import DEFAULT_REQUEST_CACHE
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -87,16 +88,23 @@ def get_dates_for_course(course_id, user=None, use_cached=True, schedule=None):
     dates = DEFAULT_REQUEST_CACHE.data.get(cache_key, None)
     if use_cached and dates is not None:
         return dates
+
     course_id = _ensure_key(CourseKey, course_id)
     qset = models.ContentDate.objects.filter(course_id=course_id, active=True).select_related('policy')
     dates = {}
     policies = {}
     for cdate in qset:
-        if schedule is None:
-            schedule = cdate.schedule_for_user(user)
+        if schedule is None and user is not None:
+            try:
+                schedule = cdate.schedule_for_user(user)
+            except ObjectDoesNotExist:
+                schedule = None
 
         key = (cdate.location, cdate.field)
-        dates[key] = cdate.policy.actual_date(schedule)
+        try:
+            dates[key] = cdate.policy.actual_date(schedule)
+        except ValueError:
+            log.warning("Unable to read date for %s", cdate.location, exc_info=True)
         policies[cdate.id] = key
     if user_id:
         for userdate in models.UserDate.objects.filter(
@@ -106,7 +114,12 @@ def get_dates_for_course(course_id, user=None, use_cached=True, schedule=None):
         ).select_related(
             'content_date', 'content_date__policy'
         ).order_by('modified'):
-            dates[policies[userdate.content_date_id]] = userdate.actual_date
+
+            try:
+                dates[policies[userdate.content_date_id]] = userdate.actual_date
+            except (ValueError, ObjectDoesNotExist):
+                log.warning("Unable to read date for %s", userdate.content_date, exc_info=True)
+
     DEFAULT_REQUEST_CACHE.data[cache_key] = dates
     return dates
 

--- a/edx_when/field_data.py
+++ b/edx_when/field_data.py
@@ -58,6 +58,7 @@ class DateLookupFieldData(FieldData):
         dates = {}
         for (location, field), date in api.get_dates_for_course(course_id, user, use_cached=use_cached).items():
             dates[text_type(location), field] = date
+
         self._course_dates = dates
 
     def has(self, block, name):

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -100,11 +100,11 @@ class ContentDate(models.Model):
 
             return Schedule.objects.get(enrollment__user__id=user, enrollment__course__id=self.course_id)
         else:
-            if not hasattr(user, 'enrollments'):
+            if not hasattr(user, 'courseenrollment_set'):
                 return None
 
             # TODO: This will break prefetching, if the user object already had enrollments/schedules prefetched
-            return user.enrollments.get(course__id=self.course_id).schedule
+            return user.courseenrollment_set.get(course__id=self.course_id).schedule
 
 
 @python_2_unicode_compatible

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,6 +83,29 @@ class ApiTests(TestCase):
         assert first_id.course_key != last_id.course_key
         return items
 
+    def test_get_dates_no_schedule(self):
+        items = make_items(with_relative=True)
+        api.set_dates_for_course(items[0][0].course_key, items)
+        retrieved = api.get_dates_for_course(items[0][0].course_key, user=self.user)
+        assert len(retrieved) == 6
+        self.schedule.delete()
+        retrieved = api.get_dates_for_course(items[0][0].course_key, user=self.user, use_cached=False)
+        assert len(retrieved) == 3
+
+    def test_get_user_date_no_schedule(self):
+        items = make_items()
+        api.set_dates_for_course(items[0][0].course_key, items)
+        before_override = api.get_dates_for_course(items[0][0].course_key, user=self.user)
+        assert len(before_override) == 3
+
+        # Override a date for the user with a relative date, but remove the schedule
+        # so that the override can't be applied
+        api.set_date_for_block(items[0][0].course_key, items[0][0], 'due', timedelta(days=2), user=self.user)
+        self.schedule.delete()
+
+        after_override = api.get_dates_for_course(items[0][0].course_key, user=self.user, use_cached=False)
+        assert before_override == after_override
+
     def test_clear_dates_for_course(self):
         items = self.test_get_dates_for_course()
         api.clear_dates_for_course(items[0][0].course_key)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -87,7 +87,7 @@ class TestContentDate(TestCase):
 
     def test_schedule_for_user_obj_no_enrollments(self):
         mock_user = Mock(wraps=self.user)
-        del mock_user.enrollments
+        del mock_user.courseenrollment_set
         assert self.content_date.schedule_for_user(mock_user) is None
 
 

--- a/tests/test_models_app/migrations/0001_initial.py
+++ b/tests/test_models_app/migrations/0001_initial.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('course', models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.DO_NOTHING, to='test_models_app.DummyCourse')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='enrollments', to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='courseenrollment_set', to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.CreateModel(

--- a/tests/test_models_app/models.py
+++ b/tests/test_models_app/models.py
@@ -24,7 +24,7 @@ class DummyEnrollment(models.Model):
     .. no_pii:
     """
 
-    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE, related_name="enrollments")
+    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE, related_name="courseenrollment_set")
 
     course = models.ForeignKey(
         DummyCourse,

--- a/tests/test_xblock_services.py
+++ b/tests/test_xblock_services.py
@@ -45,9 +45,9 @@ class XblockTests(TestCase):
         self.user.save()
 
         schedule = mock.Mock(name="schedule", start_date=datetime.datetime(2019, 4, 1))
-        User.enrollments = mock.Mock(name="enrollments")
-        User.enrollments.get.return_value.schedule = schedule
-        self.addCleanup(delattr, User, 'enrollments')
+        User.courseenrollment_set = mock.Mock(name="courseenrollment_set")
+        User.courseenrollment_set.get.return_value.schedule = schedule
+        self.addCleanup(delattr, User, 'courseenrollment_set')
 
         mock_Schedule = mock.Mock(name="Schedule")
         mock_Schedule.objects.get.return_value.schedule = schedule


### PR DESCRIPTION
CourseEnrollments don't have a `related_name` set, so they use the
`courseenrollment_set` access pattern for reverse lookups.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
