### PR TITLE
Enable relative dates based off waffle

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -17,10 +17,3 @@ auth.User:
   ".. pii_retirement:" : consumer_api
 contenttypes.ContentType:
   ".. no_pii:": "This model has no PII"
-# Via waffle
-waffle.Flag:
-  ".. no_pii:": "No PII"
-waffle.Sample:
-  ".. no_pii:": "No PII"
-waffle.Switch:
-  ".. no_pii:": "No PII"

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.7.1'
+__version__ = '1.0.0'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -25,7 +25,7 @@ except ImportError:
 @python_2_unicode_compatible
 class DatePolicy(TimeStampedModel):
     """
-    TODO: replace with a brief description of the model.
+    Stores a date (either absolute or relative).
 
     .. no_pii:
     """
@@ -67,7 +67,7 @@ class DatePolicy(TimeStampedModel):
 @python_2_unicode_compatible
 class ContentDate(models.Model):
     """
-    TODO: replace with a brief description of the model.
+    Ties a DatePolicy to a specific piece of course content. (e.g. a due date for a homework).
 
     .. no_pii:
     """
@@ -110,7 +110,7 @@ class ContentDate(models.Model):
 @python_2_unicode_compatible
 class UserDate(TimeStampedModel):
     """
-    TODO: replace with a brief description of the model.
+    Stores a user-specific date override for a given ContentDate.
 
     .. no_pii:
     """

--- a/test_settings.py
+++ b/test_settings.py
@@ -32,7 +32,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'edx_when',
-    'waffle',
     'tests.test_models_app',
 )
 

--- a/tests/test_xblock_services.py
+++ b/tests/test_xblock_services.py
@@ -61,7 +61,6 @@ class TestFieldData(XblockTests):
     Tests for the FieldData subclass.
     """
 
-    @api.override_enabled()
     def test_field_data_get(self):
         defaults = mock.MagicMock()
         dfd = field_data.DateLookupFieldData(defaults, course_id=self.course_id, use_cached=False, user=self.user)
@@ -128,7 +127,8 @@ class TransformerTests(XblockTests):
         field_data.DateOverrideTransformer.collect(block_structure)
         assert block_structure.request_xblock_fields.called_once_with('due', 'start')
 
-    def test_transform(self):
+    @mock.patch('edx_when.api._are_relative_dates_enabled', return_value=True)
+    def test_transform(self, _mock):
         override = datetime.datetime(2020, 1, 1)
         api.set_date_for_block(self.items[0][0].course_key, self.items[0][0], 'due', override, user=self.user)
         usage_info = mock.MagicMock()


### PR DESCRIPTION
With this change, the api will only return relative block dates and/or relative user override dates if a waffle flag is enabled for the given course and user.

Also, remove the unused and inaccurate api decorator override_enabled. It referenced an old waffle flag that gated all of edx-when. Due to this change, I've bumped the version to 1.0.0.

https://openedx.atlassian.net/browse/AA-27
