### PR TITLE
AA-55: Updating relative date return logic

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -113,6 +113,10 @@ def get_dates_for_course(course_id, user=None, use_cached=True, schedule=None):
     dates = {}
     policies = {}
     need_schedule = schedule is None and user is not None
+    end_content_date = list(filter(lambda cd: cd.location.block_type == 'course' and cd.field == 'end', qset))
+    end_datetime = None
+    if end_content_date:
+        end_datetime = end_content_date[0].policy.abs_date
     for cdate in qset:
         if need_schedule:
             need_schedule = False
@@ -120,7 +124,7 @@ def get_dates_for_course(course_id, user=None, use_cached=True, schedule=None):
 
         key = (cdate.location, cdate.field)
         try:
-            dates[key] = cdate.policy.actual_date(schedule)
+            dates[key] = cdate.policy.actual_date(schedule, end_datetime)
         except ValueError:
             log.warning("Unable to read date for %s", cdate.location, exc_info=True)
         policies[cdate.id] = key

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -40,7 +40,7 @@ class DatePolicy(TimeStampedModel):
         # TODO: return a string appropriate for the data fields
         return '<DatePolicy, ID: {}>'.format(self.id)
 
-    def actual_date(self, schedule=None):
+    def actual_date(self, schedule=None, end_datetime=None):
         """
         Return the normalized date.
         """
@@ -52,6 +52,11 @@ class DatePolicy(TimeStampedModel):
                         self
                     )
                 )
+            # If the course has an end date defined, we will prefer the course end date
+            # if the relative date is later than the course end date.
+            # Note: This can result in several dates being listed the same as the course end date
+            if end_datetime:
+                return min(schedule.start_date + self.rel_date, end_datetime)
             return schedule.start_date + self.rel_date
         else:
             return self.abs_date


### PR DESCRIPTION
In the scenario where the date returned for a relative date
would be past the end date (such as an assignment due date),
we want to prefer the course end date instead.