### PR TITLE
Don't write to db if nothing changed

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Try to reduce the number of writes we do when setting dates, by just checking if the data has actually changed first.
