### PR TITLE
Simple caching of ContentDate on a per course basis.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (http://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
@@ -14,7 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+[1.1.3] - 2019-03-25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Use memcache to cache ContentDate information in get_dates_for_course
+
 
 [0.1.0] - 2019-03-04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
The get_dates_for_course function makes large queries to fetch
ContentDate objects. Since this function is called from almost
any courseware operation (we fetch a whole course worth of dates
at a time when doing XBlock operations), it started putting a
lot of stress on the database under load. In order to help
alleviate some of that pressure, this commit uses memcached to
cache this data.

Ideally, we would be smarter about only grabbing the data we
actually need, rather than grabbing the entire course's date
information at once. Also, the fact that we're just shoving
model objects into the cache means that this functionality relies
on using pickle caching serialization rather than JSON, which is
worse from a security and compatibility point of view. This is not
great code, it's just the simplest/least-risky thing we can do to
get to scale the site in a hurry.