### PR TITLE
AA-68: Adds function to find users with assignments due on a day

### DIFF
--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -4,6 +4,6 @@ Your project description goes here.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
List of generated queries being run.

For User IDs of learners with UserDate overrides (only used as subquery):
```
SELECT DISTINCT "edx_when_userdate"."user_id" 
FROM "edx_when_userdate" 
INNER JOIN "edx_when_contentdate" 
ON (
    "edx_when_userdate"."content_date_id" = "edx_when_contentdate"."id"
    ) 
INNER JOIN "edx_when_datepolicy" 
ON (
    "edx_when_contentdate"."policy_id" = "edx_when_datepolicy"."id"
) 
WHERE (("edx_when_userdate"."abs_date" IS NULL 
        AND django_datetime_cast_date((django_format_dtdelta('+', "edx_when_datepolicy"."abs_date", "edx_when_userdate"."rel_date")), NULL) = 2019-03-22
    ) 
    OR (
            django_datetime_cast_date("edx_when_datepolicy"."abs_date", NULL) = 2019-03-22 AND "edx_when_userdate"."rel_date" IS NULL))
```

For Schedules of learners with UserDate overrides:
```
SELECT "test_models_app_dummyschedule"."id", "test_models_app_dummyschedule"."enrollment_id", "test_models_app_dummyschedule"."start_date" 
FROM "test_models_app_dummyschedule" 
INNER JOIN "test_models_app_dummyenrollment" 
ON (
    "test_models_app_dummyschedule"."enrollment_id" = "test_models_app_dummyenrollment"."id"
) 
WHERE (
    "test_models_app_dummyenrollment"."course_id" = course-v1:testX+tt101+2019 
    AND "test_models_app_dummyenrollment"."user_id" IN (
        SELECT DISTINCT U0."user_id" 
        FROM "edx_when_userdate" U0 
        INNER JOIN "edx_when_contentdate" U1 
        ON (
            U0."content_date_id" = U1."id"
        ) 
        INNER JOIN "edx_when_datepolicy" U2 
        ON (
            U1."policy_id" = U2."id"
        ) 
        WHERE (
            (
                U0."abs_date" IS NULL 
                AND django_datetime_cast_date((django_format_dtdelta('+', U2."abs_date", U0."rel_date")), NULL) = 2019-03-22
            ) OR (
                django_datetime_cast_date(U2."abs_date", NULL) = 2019-03-22 
                AND U0."rel_date" IS NULL
            )
        )
    )
)
```

For distinct `rel_dates` for a course:
```
SELECT DISTINCT "edx_when_datepolicy"."rel_date" 
FROM "edx_when_contentdate" 
INNER JOIN "edx_when_datepolicy" 
ON (
    "edx_when_contentdate"."policy_id" = "edx_when_datepolicy"."id"
) 
WHERE (
    "edx_when_contentdate"."course_id" = course-v1:testX+tt101+2019 
    AND "edx_when_datepolicy"."rel_date" IS NOT NULL
)
```

For all Schedules for learners with a UserDate override or an abs/rel due date today:
```
SELECT "test_models_app_dummyschedule"."id", "test_models_app_dummyschedule"."enrollment_id", "test_models_app_dummyschedule"."start_date", "test_models_app_dummyenrollment"."id", "test_models_app_dummyenrollment"."user_id", "test_models_app_dummyenrollment"."course_id" 
FROM "test_models_app_dummyschedule" 
INNER JOIN "test_models_app_dummyenrollment" 
ON (
    "test_models_app_dummyschedule"."enrollment_id" = "test_models_app_dummyenrollment"."id"
) 
WHERE (
    (
        "test_models_app_dummyenrollment"."course_id" = course-v1:testX+tt101+2019 
        AND django_datetime_cast_date("test_models_app_dummyschedule"."start_date", NULL) IN (
            2019-03-21, 2019-03-15, 2019-03-22
        ) 
        AND NOT (
            "test_models_app_dummyenrollment"."user_id" IN (
                SELECT DISTINCT U0."user_id" 
                FROM "edx_when_userdate" U0 
                INNER JOIN "edx_when_contentdate" U1 
                ON (
                    U0."content_date_id" = U1."id"
                ) 
                INNER JOIN "edx_when_datepolicy" U2 
                ON (
                    U1."policy_id" = U2."id"
                ) 
                WHERE (
                    (
                        U0."abs_date" IS NULL 
                        AND django_datetime_cast_date((django_format_dtdelta('+', U2."abs_date", U0."rel_date")), NULL) = 2019-03-22
                    ) 
                    OR (
                        django_datetime_cast_date(U2."abs_date", NULL) = 2019-03-22 
                        AND U0."rel_date" IS NULL
                    )
                )
            )
        )
    ) OR (
        "test_models_app_dummyenrollment"."course_id" = course-v1:testX+tt101+2019 
        AND "test_models_app_dummyenrollment"."user_id" IN (
            SELECT DISTINCT U0."user_id" 
            FROM "edx_when_userdate" U0 
            INNER JOIN "edx_when_contentdate" U1 
            ON (
                U0."content_date_id" = U1."id"
            ) 
            INNER JOIN "edx_when_datepolicy" U2 
            ON (
                U1."policy_id" = U2."id"
            ) 
            WHERE (
                (
                    U0."abs_date" IS NULL 
                    AND django_datetime_cast_date((django_format_dtdelta('+', U2."abs_date", U0."rel_date")), NULL) = 2019-03-22
                ) OR (
                    django_datetime_cast_date(U2."abs_date", NULL) = 2019-03-22 AND U0."rel_date" IS NULL
                )
            )
        )
    )
)
```