### PR TITLE
AA-195: Don't give rel dates past cutoff date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,24 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.2.9] - 2020-06-30
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Don't return due dates for enrollments originally created too close to the
+course end to allow for finishing the course in time.
+
+[1.2.8] - 2020-06-17
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Don't return due dates for enrollments created after course end
+
+[1.2.4] - 2020-06-01
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Updates function in API for finding learners with a specific Schedule
+that has an assignment on a given day, to also be inclusive of absolute
+date schedules (everyone active in the course without an override).
+
 [1.2.3] - 2020-04-30
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = '1.2.8'
+__version__ = '1.2.9'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -40,9 +40,14 @@ class DatePolicy(TimeStampedModel):
         """
         return str(self.abs_date) if self.abs_date else str(self.rel_date)
 
-    def actual_date(self, schedule=None, end_datetime=None):
+    def actual_date(self, schedule=None, end_datetime=None, cutoff_datetime=None):
         """
         Return the normalized date.
+
+        Arguments:
+            schedule (Schedule): user schedule, only used for relative dates
+            end_datetime (datetime): no relative dates will be given after this date
+            cutoff_datetime (datetime): no relative dates will be given if user originally started past this date
         """
         if self.rel_date is not None:
             if schedule is None:
@@ -53,8 +58,10 @@ class DatePolicy(TimeStampedModel):
                     )
                 )
 
-            # If the user enrolled after the course ended, we don't want to return any dates.
-            if end_datetime and schedule.start_date > end_datetime:
+            # If the user first enrolled after the cutoff date (or reset their schedule after the course end), we
+            # don't want to return any dates.
+            if ((cutoff_datetime and schedule.created > cutoff_datetime) or
+                    (end_datetime and schedule.start_date > end_datetime)):
                 return None
 
             # If the course has an end date defined, we will prefer the course end date

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,6 +52,14 @@ class TestDatePolicy(TestCase):
         schedule = DummySchedule(start_date=datetime(2020, 4, 1))
         self.assertIsNone(policy.actual_date(schedule, end_datetime=datetime(2020, 1, 1)))
 
+    def test_actual_date_schedule_after_cutoff(self):
+        # This only applies for relative dates so we are not testing abs date.
+        day = timedelta(days=1)
+        policy = DatePolicy(rel_date=day)
+        schedule = DummySchedule(start_date=datetime(2020, 4, 1))
+        self.assertIsNone(policy.actual_date(schedule, cutoff_datetime=(schedule.created - day)))
+        self.assertIsNotNone(policy.actual_date(schedule, cutoff_datetime=(schedule.created + day)))
+
     def test_mixed_dates(self):
         with self.assertRaises(ValidationError):
             DatePolicy(abs_date=datetime(2020, 1, 1), rel_date=timedelta(days=1)).full_clean()

--- a/tests/test_models_app/migrations/0001_initial.py
+++ b/tests/test_models_app/migrations/0001_initial.py
@@ -36,6 +36,7 @@ class Migration(migrations.Migration):
             name='DummySchedule',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', models.DateTimeField()),
                 ('start_date', models.DateTimeField(db_index=True, help_text='Date this schedule went into effect')),
                 ('enrollment', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to='test_models_app.DummyEnrollment')),
             ],

--- a/tests/test_models_app/models.py
+++ b/tests/test_models_app/models.py
@@ -38,8 +38,15 @@ class DummySchedule(models.Model):
     .. no_pii:
     """
 
+    created = models.DateTimeField()
     enrollment = models.OneToOneField(DummyEnrollment, null=False, on_delete=models.CASCADE, related_name="schedule")
     start_date = models.DateTimeField(
         db_index=True,
         help_text='Date this schedule went into effect'
     )
+
+    def __init__(self, *args, created=None, start_date=None, **kwargs):
+        # Ensure we have a created value, if possible
+        if not created and start_date:
+            created = start_date
+        super().__init__(*args, created=created, start_date=start_date, **kwargs)


### PR DESCRIPTION
The cutoff date is the point past which the learner will not have time to complete the course, because expected due dates would be due past the course end date.

This new check only considers if the learner's original schedule was past the cutoff, it does not consider schedules that have been reset. (i.e. we still allow for learners that reset their schedule close to the course end date, by clustering their due dates at course end).

Related to https://github.com/edx/frontend-app-learning/pull/100