### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.3.1] - 2020-11-19
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Updated travis badge in README.rst to point to travis-ci.com instead of travis-ci.org
+
+
 [1.3.0] - 2020-07-16
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,8 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-when/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/edx-when.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-when
+.. |travis-badge| image:: https://travis-ci.com/edx/edx-when.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-when
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/edx-when/coverage.svg?branch=master

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the README file.
Travis badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089