### PR TITLE
Don't warn if we're missing a schedule for relative dates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.3.2] - 2021-01-15
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Don't warn about missing schedules for relative dates.
+It happens for legitimate reasons, and the layer above can check instead.
+
 [1.3.1] - 2020-11-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Updated travis badge in README.rst to point to travis-ci.com instead of travis-ci.org

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 default_app_config = 'edx_when.apps.EdxWhenConfig'  # pylint: disable=invalid-name

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -193,8 +193,10 @@ def get_dates_for_course(course_id, user=None, use_cached=True, schedule=None):
         key = (cdate.location.map_into_course(course_id), cdate.field)
         try:
             dates[key] = cdate.policy.actual_date(schedule, end_datetime, cutoff_datetime)
-        except ValueError:
-            log.warning("Unable to read date for %s", cdate.location, exc_info=True)
+        except models.MissingScheduleError:
+            # We had a relative date but no schedule. This is permissible in some cases (staff users viewing a course
+            # they are not enrolled in, for example). Just let it go by.
+            pass
         policies[cdate.id] = key
 
     if user_id:

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -19,6 +19,10 @@ except ImportError:
     Schedule = None
 
 
+class MissingScheduleError(ValueError):
+    pass
+
+
 class DatePolicy(TimeStampedModel):
     """
     Stores a date (either absolute or relative).
@@ -51,7 +55,7 @@ class DatePolicy(TimeStampedModel):
         """
         if self.rel_date is not None:
             if schedule is None:
-                raise ValueError(
+                raise MissingScheduleError(
                     "Can't interpret relative date {} for {!r} without a user schedule".format(
                         self.rel_date,
                         self

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.test import TestCase
 from mock import patch
 
-from edx_when.models import ContentDate, DatePolicy
+from edx_when.models import ContentDate, DatePolicy, MissingScheduleError
 from tests.test_models_app.models import DummyCourse, DummyEnrollment, DummySchedule
 
 User = get_user_model()
@@ -43,7 +43,7 @@ class TestDatePolicy(TestCase):
     @ddt.unpack
     def test_actual_date_failure(self, abs_date, rel_date, schedule):
         policy = DatePolicy(abs_date=abs_date, rel_date=rel_date)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(MissingScheduleError):
             policy.actual_date(schedule)
 
     def test_actual_date_schedule_after_end(self):


### PR DESCRIPTION
It happens for legitimate reasons like staff users viewing a course they are not enrolled in.

If edx-platform cares about it, they can check on their side (and thus just log once instead of many times).