### PR TITLE
fix: set DJANGO_SETTINGS_MODULE for quality test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,8 @@ commands =
 	python setup.py check --restructuredtext --strict
 
 [testenv:quality]
+setenv =
+	DJANGO_SETTINGS_MODULE = test_settings
 whitelist_externals = 
 	make
 	rm


### PR DESCRIPTION
This is required for newer pylint-django versions.