### PR TITLE
chore: updated CI badge to point to GitHub Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-when/
     :alt: PyPI
 
-.. |CI| image:: image:: https://github.com/edx/edx-when/workflows/Python%20CI/badge.svg?branch=master
+.. |CI| image:: https://github.com/edx/edx-when/workflows/Python%20CI/badge.svg?branch=master
     :target: https://github.com/edx/edx-when/actions?query=workflow%3A%22Python+CI%22
     :alt: CI
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 edx-when
 =============================
 
-|pypi-badge| |travis-badge| |codecov-badge| |doc-badge| |pyversions-badge|
+|pypi-badge| |CI| |codecov-badge| |doc-badge| |pyversions-badge|
 |license-badge|
 
 Overview
@@ -58,9 +58,9 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-when/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.com/edx/edx-when.svg?branch=master
-    :target: https://travis-ci.com/edx/edx-when
-    :alt: Travis
+.. |CI| image:: image:: https://github.com/edx/edx-when/workflows/Python%20CI/badge.svg?branch=master
+    :target: https://github.com/edx/edx-when/actions?query=workflow%3A%22Python+CI%22
+    :alt: CI
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/edx-when/coverage.svg?branch=master
     :target: http://codecov.io/github/edx/edx-when?branch=master


### PR DESCRIPTION
Updated CI badge to point to GitHub Actions instead of Travis 

JIRA: https://openedx.atlassian.net/browse/BOM-2730